### PR TITLE
Added a custom save path control.

### DIFF
--- a/deemon/__init__.py
+++ b/deemon/__init__.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python3
 
-__version__ = '1.3'
-__dbversion__ = '1.3'
+__version__ = '1.4-beta2'
+__dbversion__ = '1.3.1'

--- a/deemon/app/db.py
+++ b/deemon/app/db.py
@@ -61,11 +61,11 @@ class DBHelper:
         # TODO MOVE TO ONE SQL STATEMENT OR BREAK INTO VERSIONED GROUPS
         sql_monitor = ("CREATE TABLE IF NOT EXISTS 'monitor' "
                        "('artist_id' INTEGER, 'artist_name' TEXT, 'bitrate' INTEGER, "
-                       "'record_type' TEXT, 'alerts' INTEGER)")
+                       "'record_type' TEXT, 'alerts' INTEGER, 'downloadPath' TEXT)")
 
         sql_playlists = ("CREATE TABLE IF NOT EXISTS 'playlists' "
                          "('id' INTEGER UNIQUE, 'title' TEXT, 'url' TEXT, "
-                         "'bitrate' INTEGER, 'alerts' INTEGER)")
+                         "'bitrate' INTEGER, 'alerts' INTEGER, 'downloadPath' TEXT)")
 
         sql_playlist_tracks = ("CREATE TABLE IF NOT EXISTS 'playlist_tracks' "
                                "('track_id' INTEGER, 'playlist_id' INTEGER, 'artist_id' INTEGER, "

--- a/deemon/app/db.py
+++ b/deemon/app/db.py
@@ -61,11 +61,11 @@ class DBHelper:
         # TODO MOVE TO ONE SQL STATEMENT OR BREAK INTO VERSIONED GROUPS
         sql_monitor = ("CREATE TABLE IF NOT EXISTS 'monitor' "
                        "('artist_id' INTEGER, 'artist_name' TEXT, 'bitrate' INTEGER, "
-                       "'record_type' TEXT, 'alerts' INTEGER, 'downloadPath' TEXT)")
+                       "'record_type' TEXT, 'alerts' INTEGER, 'download_path' TEXT)")
 
         sql_playlists = ("CREATE TABLE IF NOT EXISTS 'playlists' "
                          "('id' INTEGER UNIQUE, 'title' TEXT, 'url' TEXT, "
-                         "'bitrate' INTEGER, 'alerts' INTEGER, 'downloadPath' TEXT)")
+                         "'bitrate' INTEGER, 'alerts' INTEGER, 'download_path' TEXT)")
 
         sql_playlist_tracks = ("CREATE TABLE IF NOT EXISTS 'playlist_tracks' "
                                "('track_id' INTEGER, 'playlist_id' INTEGER, 'artist_id' INTEGER, "
@@ -119,6 +119,11 @@ class DBHelper:
             self.query(sql_updatever)
             self.commit()
             logger.debug(f"Database upgraded to version 1.3")
+        if current_ver < parse_version("1.3.1"):
+            self.query("ALTER TABLE monitor ADD COLUMN download_path TEXT")
+            self.query("ALTER TABLE playlists ADD COLUMN download_path TEXT")
+            self.query("INSERT OR REPLACE INTO 'deemon' ('property', 'value') VALUES ('version', '1.3.1')")
+            self.commit()
 
     def query(self, query, values=None):
         if values is None:

--- a/deemon/app/dmi.py
+++ b/deemon/app/dmi.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from pprint import pprint
 import deemix
 from deezer import Deezer
 from deezer.api import APIError
@@ -37,9 +38,23 @@ class DeemixInterface(Deemon):
         logger.debug(f"deemix Config Path: {self.config_dir}")
         logger.debug(f"deemix Download Path: {self.dx_settings['downloadLocation']}")
 
-    def download_url(self, url, bitrate, override_deemix=True):
+
+    def setDownloadPath(self, downloadLocationPath):
+        downloadLocationPath = str(downloadLocationPath)
+        if (Path(downloadLocationPath).exists):
+            self.dx_settings['downloadLocation'] = str(downloadLocationPath)
+            logger.debug(f"deemix Download Path changed to: {self.dx_settings['downloadLocation']}")
+        else:
+            logger.debug(f"User entered invalid Download Path (No change) : {self.dx_settings['downloadLocation']}")
+
+
+
+    def download_url(self, url, bitrate, override_deemix=True, downloadPath=""):
         if override_deemix:
             deemix.generatePlaylistItem = self.generatePlaylistItem
+        if downloadPath != "":
+            self.setDownloadPath(downloadPath)
+        
         links = []
         for link in url:
             if ';' in link:

--- a/deemon/app/dmi.py
+++ b/deemon/app/dmi.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from pprint import pprint
 import deemix
 from deezer import Deezer
 from deezer.api import APIError

--- a/deemon/app/dmi.py
+++ b/deemon/app/dmi.py
@@ -5,7 +5,7 @@ from deezer.api import APIError
 from deezer.utils import map_user_playlist
 from deezer.gw import GWAPIError, LyricsStatus
 from deemix import generateDownloadObject
-from deemix.types.DownloadObjects import Single, Collection
+from deemix.types.DownloadObjects import Collection
 from deemix.downloader import Downloader
 from deemix.settings import load as loadSettings
 from deemon.app import Deemon
@@ -15,12 +15,12 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class DeemixInterface(Deemon):
-    def __init__(self):
-        super().__init__()
+class DeemixInterface:
+    def __init__(self, config):
         logger.debug("Initializing deemix library")
 
         self.dz = Deezer()
+        self.config = config
 
         if self.config["deemix_path"] == "":
             self.config_dir = localpaths.getConfigFolder()
@@ -37,23 +37,13 @@ class DeemixInterface(Deemon):
         logger.debug(f"deemix Config Path: {self.config_dir}")
         logger.debug(f"deemix Download Path: {self.dx_settings['downloadLocation']}")
 
-
-    def setDownloadPath(self, downloadLocationPath):
-        downloadLocationPath = str(downloadLocationPath)
-        if (Path(downloadLocationPath).exists):
-            self.dx_settings['downloadLocation'] = str(downloadLocationPath)
-            logger.debug(f"deemix Download Path changed to: {self.dx_settings['downloadLocation']}")
-        else:
-            logger.debug(f"User entered invalid Download Path (No change) : {self.dx_settings['downloadLocation']}")
-
-
-
-    def download_url(self, url, bitrate, override_deemix=True, downloadPath=""):
+    def download_url(self, url, bitrate, download_path, override_deemix=True):
         if override_deemix:
             deemix.generatePlaylistItem = self.generatePlaylistItem
-        if downloadPath != "":
-            self.setDownloadPath(downloadPath)
-        
+
+        if download_path and download_path != "":
+            self.dx_settings['downloadLocation'] = download_path
+
         links = []
         for link in url:
             if ';' in link:

--- a/deemon/app/download.py
+++ b/deemon/app/download.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import plexapi.exceptions
 from plexapi.server import PlexServer
-from deemon.app import dmi, Deemon, utils
+from deemon.app import dmi, utils
 import logging
 import deezer
 import sys
@@ -12,8 +12,8 @@ logger = logging.getLogger(__name__)
 
 
 class QueueItem:
-
-    def __init__(self, bitrate, artist=None, album=None, playlist=None, downloadPath=""):  # TODO - Accept new playlist tracks for output/alerts
+    # TODO - Accept new playlist tracks for output/alerts
+    def __init__(self, download_path, bitrate, artist=None, album=None, playlist=None):
         self.artist_name = None
         self.bitrate = bitrate
         self.album_id = None
@@ -21,7 +21,7 @@ class QueueItem:
         self.url = None
         self.playlist_title = None
         self.verbose = os.environ.get('VERBOSE')
-        self.downloadPath = downloadPath
+        self.download_path = download_path
 
         if artist:
             self.artist_name = artist["name"]
@@ -39,7 +39,6 @@ class QueueItem:
             self.url = playlist["link"]
             self.playlist_title = playlist["title"]
 
-
         self.print_queue_to_log()
 
     def print_queue_to_log(self):
@@ -49,11 +48,11 @@ class QueueItem:
 
 class Download:
 
-    def __init__(self):
+    def __init__(self, config):
         super().__init__()
         self.dz = deezer.Deezer()
-        self.di = dmi.DeemixInterface()
-        self.config = Deemon().config
+        self.config = config
+        self.di = dmi.DeemixInterface(self.config)
         self.queue_list = []
         self.bitrate = None
         self.verbose = os.environ.get("VERBOSE")
@@ -98,17 +97,17 @@ class Download:
                     logger.debug(f"Processing queue item {vars(q)}")
                 if q.artist_name:
                     logger.info(f"+ {q.artist_name} - {q.album_title}... ")
-                    self.di.download_url([q.url], q.bitrate, downloadPath=q.downloadPath)
+                    self.di.download_url([q.url], q.bitrate, q.download_path)
                 else:
                     logger.info(f"+ {q.playlist_title} (playlist)...")
-                    self.di.download_url([q.url], q.bitrate, override_deemix=False, downloadPath=q.downloadPath)
+                    self.di.download_url([q.url], q.bitrate,  q.download_path, override_deemix=False)
 
             print("")
             logger.info("Downloads complete!")
             if plex and (self.config["plex_library"] != ""):  # TODO - config validation should be done elsewhere
                 self.refresh_plex(plex)
 
-    def download(self, artist, artist_id, album_id, url, bitrate, record_type, input_file, auto=True, downloadPath=""):
+    def download(self, artist, artist_id, album_id, url, bitrate, record_type, input_file, auto=True):
 
         def filter_artist_by_record_type(artist, record_type):
             album_api = self.dz.api.get_artist_albums(artist['id'])['data']
@@ -142,7 +141,7 @@ class Download:
             filtered = filter_artist_by_record_type(api_object, record_type)
             for album in filtered:
                 if not queue_item_exists(album['id']):
-                    self.queue_list.append(QueueItem(bitrate, api_object, album, downloadPath=downloadPath))
+                    self.queue_list.append(QueueItem(self.config['download_path'], bitrate, api_object, album))
 
         def queue_item_exists(i):
             for q in self.queue_list:
@@ -159,24 +158,24 @@ class Download:
             if artist_result:
                 queue_filtered_releases(artist_result)
 
-        def process_artist_by_id(id):
+        def process_artist_by_id(i):
             logger.debug("Processing artists by ID")
-            artist_id_result = get_api_result(artist_id=id)
-            logger.debug(f"Requested Artist ID: {id}, Found: {artist_id_result['name']}")
+            artist_id_result = get_api_result(artist_id=i)
+            logger.debug(f"Requested Artist ID: {i}, Found: {artist_id_result['name']}")
             if artist_id_result:
                 queue_filtered_releases(artist_id_result)
 
-        def process_album_by_id(id):
+        def process_album_by_id(i):
             logger.debug("Processing album by name")
-            album_id_result = get_api_result(album_id=id)
-            logger.debug(f"Requested Album: {id}, "
+            album_id_result = get_api_result(album_id=i)
+            logger.debug(f"Requested Album: {i}, "
                          f"Found: {album_id_result['artist']['name']} - {album_id_result['title']}")
             if album_id_result and not queue_item_exists(album_id_result['id']):
-                self.queue_list.append(QueueItem(bitrate, album=album_id_result, downloadPath=downloadPath))
+                self.queue_list.append(QueueItem(self.config['download_path'], bitrate, album=album_id_result))
 
         def process_playlist_by_id(id):
             playlist_api = self.dz.api.get_playlist(id)
-            self.queue_list.append(QueueItem(bitrate, playlist=playlist_api, downloadPath=downloadPath))
+            self.queue_list.append(QueueItem(self.config['download_path'], bitrate, playlist=playlist_api))
 
         def extract_id_from_url(url):
             id_group = ['artist', 'album', 'playlist']
@@ -186,7 +185,7 @@ class Download:
                     id = int(url.split(f'/{group}/')[1])
                     logger.debug(f"Extracted group={id_type}, id={id}")
                     return id_type, id
-                except (IndexError, ValueError) as e:
+                except (IndexError, ValueError):
                     continue
             return False, False
 

--- a/deemon/app/download.py
+++ b/deemon/app/download.py
@@ -7,7 +7,6 @@ import logging
 import deezer
 import sys
 import os
-from pprint import pprint
 
 logger = logging.getLogger(__name__)
 

--- a/deemon/app/download.py
+++ b/deemon/app/download.py
@@ -22,8 +22,7 @@ class QueueItem:
         self.url = None
         self.playlist_title = None
         self.verbose = os.environ.get('VERBOSE')
-        self.downloadPath = ""
-
+        self.downloadPath = downloadPath
 
         if artist:
             self.artist_name = artist["name"]
@@ -41,9 +40,6 @@ class QueueItem:
             self.url = playlist["link"]
             self.playlist_title = playlist["title"]
 
-        if downloadPath:
-            if (Path(downloadPath).exists):
-                self.downloadPath = downloadPath
 
         self.print_queue_to_log()
 

--- a/deemon/app/monitor.py
+++ b/deemon/app/monitor.py
@@ -13,10 +13,6 @@ def monitor(profile, value, bitrate, r_type, alerts, remove=False, reset=False, 
     dz = deezer.Deezer()
     db = Deemon().db
 
-    if downloadPath != "":
-        if not (Path(downloadPath).exists):
-            downloadPath = ""
-
     def purge_playlist(i, title):
         values = {'id': api_result['id']}
         db.query("DELETE FROM 'playlists' WHERE id = :id", values)

--- a/deemon/app/refresh.py
+++ b/deemon/app/refresh.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 class Refresh:
 
-    def __init__(self, artist_id=None, playlist_id=None, skip_download=False, time_machine=None, dl_obj=None):
+    def __init__(self, config, artist_id=None, playlist_id=None, skip_download=False, time_machine=None, dl_obj=None):
         self.artist_id = artist_id if artist_id else None
         self.playlist_id = playlist_id if playlist_id else None
         self.skip_download = skip_download
@@ -18,7 +18,7 @@ class Refresh:
         self.new_releases = []
         self.refresh_date = self.set_refresh_date()
         self.db = Deemon().db
-        self.config = Deemon().config
+        self.config = config
         self.dz = deezer.Deezer()
 
         if not dl_obj:
@@ -62,7 +62,7 @@ class Refresh:
 
         if len(self.queue_list) > 0 and not self.skip_download:
             if not self.dl:
-                self.dl = download.Download()
+                self.dl = download.Download(self.config)
                 self.dl.queue_list = self.queue_list
                 self.dl.download_queue()
             else:
@@ -101,8 +101,9 @@ class Refresh:
                     new_track_count += 1
 
             if new_track_count > 0 and not new_playlist:
-                pl = {'id': playlist[0], 'title': playlist[1], 'link': playlist[2],'bitrate': playlist[3], 'downloadPath': playlist[5]}
-                self.queue_list.append(download.QueueItem(pl['bitrate'], playlist=pl, downloadPath=pl['downloadPath']))
+                pl = {'id': playlist[0], 'title': playlist[1], 'link': playlist[2],'bitrate': playlist[3],
+                      'download_path': playlist[5]}
+                self.queue_list.append(download.QueueItem(pl['bitrate'], playlist=pl))
                 logger.info(f"Playlist '{playlist_api['title']}' has {new_track_count} new track(s)")
             else:
                 logger.debug(f"No new tracks have been added to playlist '{playlist_api['title']}'")
@@ -123,14 +124,15 @@ class Refresh:
         for artist in progress:
             
             artist = {"id": artist[0], "name": artist[1], "bitrate": artist[2],
-                      "record_type": artist[3], "alerts": artist[4], "downloadPath": artist[5]}  # TODO This could be cleaned up using rowfactory
+                      "record_type": artist[3], "alerts": artist[4], "download_path": artist[5]}
             artist_new_release_count = 0
             new_artist = self.existing_artist(artist['id'])
             progress.set_description_str("Refreshing artists")
             artist_albums = self.dz.api.get_artist_albums(artist['id'])['data']
 
             logger.debug(f"Artist settings for {artist['name']} ({artist['id']}): bitrate={artist['bitrate']}, "
-                         f"record_type={artist['record_type']}, alerts={artist['alerts']}, downloadPath={artist['downloadPath']}")
+                         f"record_type={artist['record_type']}, alerts={artist['alerts']}, "
+                         f"download_path={artist['download_path']}")
             for album in artist_albums:
                 exists = self.db.get_album_by_id(album_id=album['id'])
                 if exists:
@@ -165,7 +167,8 @@ class Refresh:
                     self.total_new_releases += 1
                     artist_new_release_count += 1
 
-                    self.queue_list.append(download.QueueItem(artist['bitrate'], artist, album, None, downloadPath=artist['downloadPath']))
+                    self.queue_list.append(download.QueueItem(artist['download_path'], artist['bitrate'],
+                                                              artist, album, None))
                     logger.debug(f"Release {album['id']} added to queue")
                     if artist["alerts"]:
                         self.append_new_release(album['release_date'], artist['name'],

--- a/deemon/cli.py
+++ b/deemon/cli.py
@@ -87,7 +87,7 @@ def download_command(artist, artist_id, album_id, url, file, bitrate, record_typ
               default=config["record_type"], help='Specify record types to download')
 @click.option('-a', '--alerts', type=int, default=config["alerts"], help="Enable or disable alerts")
 @click.option('-n', '--no-refresh', is_flag=True, help='Skip refresh after adding or removing artist')
-@click.option('-D', '--download', 'dl', metavar="PATH", help='Download all releases matching record type (Download Path optional)')
+@click.option('-D', '--download', 'dl', default=config["download_path"], help='Download all releases matching record type (Download Path optional)')
 @click.option('-R', '--remove', is_flag=True, help='Stop monitoring an artist')
 @click.option('--reset', is_flag=True, help='Remove all artists/playlists from monitoring')
 def monitor_command(artist, im, playlist, no_refresh, bitrate, record_type, alerts, artist_id, remove, url, reset, dl):

--- a/deemon/cli.py
+++ b/deemon/cli.py
@@ -87,10 +87,11 @@ def download_command(artist, artist_id, album_id, url, file, bitrate, record_typ
               default=config["record_type"], help='Specify record types to download')
 @click.option('-a', '--alerts', type=int, default=config["alerts"], help="Enable or disable alerts")
 @click.option('-n', '--no-refresh', is_flag=True, help='Skip refresh after adding or removing artist')
-@click.option('-D', '--download', 'dl', default=config["download_path"], help='Download all releases matching record type (Download Path optional)')
+@click.option('-D', '--download', 'dl', is_flag=True, help='Download all releases matching record type')
+@click.option('--download-path', type=click.Path(), default=config["download_path"], metavar="PATH", help='Path where the artist(s), playlist(s) will be saved')
 @click.option('-R', '--remove', is_flag=True, help='Stop monitoring an artist')
 @click.option('--reset', is_flag=True, help='Remove all artists/playlists from monitoring')
-def monitor_command(artist, im, playlist, no_refresh, bitrate, record_type, alerts, artist_id, remove, url, reset, dl):
+def monitor_command(artist, im, playlist, no_refresh, bitrate, record_type, alerts, artist_id, remove, url, reset, dl, download_path):
     """
     Monitor artist for new releases by ID, URL or name.
 
@@ -113,7 +114,6 @@ def monitor_command(artist, im, playlist, no_refresh, bitrate, record_type, aler
     url = list(url)
     playlists = list(playlist)
 
-    downloadPath = ""
     new_artists = []
     new_playlists = []
 
@@ -121,7 +121,6 @@ def monitor_command(artist, im, playlist, no_refresh, bitrate, record_type, aler
     bitrate = utils.validate_bitrate(bitrate)
 
     if dl:
-        downloadPath = dl
         dl = download.Download()
 
     if im:
@@ -130,18 +129,18 @@ def monitor_command(artist, im, playlist, no_refresh, bitrate, record_type, aler
             artist_int_list, artist_str_list = utils.process_input_file(imported_file)
             if artist_str_list:
                 for a in artist_str_list:
-                    result = monitor.monitor("artist", a, bitrate, record_type, alerts, remove=remove, dl_obj=dl, downloadPath=downloadPath)
+                    result = monitor.monitor("artist", a, bitrate, record_type, alerts, remove=remove, dl_obj=dl, downloadPath=download_path)
                     if type(result) == int:
                         new_artists.append(result)
             if artist_int_list:
                 for aid in artist_int_list:
-                    result = monitor.monitor("artist_id", aid, bitrate, record_type, alerts, remove=remove, dl_obj=dl, downloadPath=downloadPath)
+                    result = monitor.monitor("artist_id", aid, bitrate, record_type, alerts, remove=remove, dl_obj=dl, downloadPath=download_path)
                     if type(result) == int:
                         new_artists.append(result)
         elif Path(im).is_dir():
             import_list = [x.relative_to(im) for x in sorted(Path(im).iterdir()) if x.is_dir()]
             for a in import_list:
-                result = monitor.monitor("artist", a, bitrate, record_type, alerts, remove=remove, dl_obj=dl, downloadPath=downloadPath)
+                result = monitor.monitor("artist", a, bitrate, record_type, alerts, remove=remove, dl_obj=dl, downloadPath=download_path)
                 if type(result) == int:
                     new_artists.append(result)
         else:
@@ -150,7 +149,7 @@ def monitor_command(artist, im, playlist, no_refresh, bitrate, record_type, aler
 
     if artist:
         for a in artists_to_csv(artist):
-            result = monitor.monitor("artist", a, bitrate, record_type, alerts, remove=remove, dl_obj=dl, downloadPath=downloadPath)
+            result = monitor.monitor("artist", a, bitrate, record_type, alerts, remove=remove, dl_obj=dl, downloadPath=download_path)
             if type(result) == int:
                 new_artists.append(result)
 
@@ -166,13 +165,13 @@ def monitor_command(artist, im, playlist, no_refresh, bitrate, record_type, aler
 
     if artist_id:
         for aid in artist_id:
-            result = monitor.monitor("artist_id", aid, bitrate, record_type, alerts, remove=remove, dl_obj=dl, downloadPath=downloadPath)
+            result = monitor.monitor("artist_id", aid, bitrate, record_type, alerts, remove=remove, dl_obj=dl, downloadPath=download_path)
             if type(result) == int:
                 new_artists.append(result)
 
     if playlists:
         for p in playlists:
-            result = monitor.monitor("playlist", p, bitrate, record_type, alerts, remove=remove, dl_obj=dl, downloadPath=downloadPath)
+            result = monitor.monitor("playlist", p, bitrate, record_type, alerts, remove=remove, dl_obj=dl, downloadPath=download_path)
             if type(result) == int:  # TODO is this needed? What return values are possible? if result > 0?
                 new_playlists.append(result)
 

--- a/deemon/cli.py
+++ b/deemon/cli.py
@@ -120,6 +120,10 @@ def monitor_command(artist, im, playlist, no_refresh, bitrate, record_type, aler
     alerts = utils.validate_alerts(alerts)
     bitrate = utils.validate_bitrate(bitrate)
 
+    if download_path:
+        if not (Path(download_path).exists):
+            download_path = config["download_path"]
+
     if dl:
         dl = download.Download()
 

--- a/deemon/cli.py
+++ b/deemon/cli.py
@@ -32,7 +32,7 @@ def run(verbose):
     """
     setup_logger(log_level='DEBUG' if verbose else 'INFO', log_file=utils.get_log_file())
 
-    new_version = utils.check_version()
+    new_version = 0 #utils.check_version()
     if new_version:
         print("*" * 50)
         logger.info(f"* New version is available: v{__version__} -> v{new_version}")
@@ -87,7 +87,7 @@ def download_command(artist, artist_id, album_id, url, file, bitrate, record_typ
               default=config["record_type"], help='Specify record types to download')
 @click.option('-a', '--alerts', type=int, default=config["alerts"], help="Enable or disable alerts")
 @click.option('-n', '--no-refresh', is_flag=True, help='Skip refresh after adding or removing artist')
-@click.option('-D', '--download', 'dl', is_flag=True, help='Download all releases matching record type')
+@click.option('-D', '--download', 'dl', metavar="PATH", help='Download all releases matching record type (Download Path optional)')
 @click.option('-R', '--remove', is_flag=True, help='Stop monitoring an artist')
 @click.option('--reset', is_flag=True, help='Remove all artists/playlists from monitoring')
 def monitor_command(artist, im, playlist, no_refresh, bitrate, record_type, alerts, artist_id, remove, url, reset, dl):
@@ -113,6 +113,7 @@ def monitor_command(artist, im, playlist, no_refresh, bitrate, record_type, aler
     url = list(url)
     playlists = list(playlist)
 
+    downloadPath = ""
     new_artists = []
     new_playlists = []
 
@@ -120,6 +121,7 @@ def monitor_command(artist, im, playlist, no_refresh, bitrate, record_type, aler
     bitrate = utils.validate_bitrate(bitrate)
 
     if dl:
+        downloadPath = dl
         dl = download.Download()
 
     if im:
@@ -128,18 +130,18 @@ def monitor_command(artist, im, playlist, no_refresh, bitrate, record_type, aler
             artist_int_list, artist_str_list = utils.process_input_file(imported_file)
             if artist_str_list:
                 for a in artist_str_list:
-                    result = monitor.monitor("artist", a, bitrate, record_type, alerts, remove=remove, dl_obj=dl)
+                    result = monitor.monitor("artist", a, bitrate, record_type, alerts, remove=remove, dl_obj=dl, downloadPath=downloadPath)
                     if type(result) == int:
                         new_artists.append(result)
             if artist_int_list:
                 for aid in artist_int_list:
-                    result = monitor.monitor("artist_id", aid, bitrate, record_type, alerts, remove=remove, dl_obj=dl)
+                    result = monitor.monitor("artist_id", aid, bitrate, record_type, alerts, remove=remove, dl_obj=dl, downloadPath=downloadPath)
                     if type(result) == int:
                         new_artists.append(result)
         elif Path(im).is_dir():
             import_list = [x.relative_to(im) for x in sorted(Path(im).iterdir()) if x.is_dir()]
             for a in import_list:
-                result = monitor.monitor("artist", a, bitrate, record_type, alerts, remove=remove, dl_obj=dl)
+                result = monitor.monitor("artist", a, bitrate, record_type, alerts, remove=remove, dl_obj=dl, downloadPath=downloadPath)
                 if type(result) == int:
                     new_artists.append(result)
         else:
@@ -148,7 +150,7 @@ def monitor_command(artist, im, playlist, no_refresh, bitrate, record_type, aler
 
     if artist:
         for a in artists_to_csv(artist):
-            result = monitor.monitor("artist", a, bitrate, record_type, alerts, remove=remove, dl_obj=dl)
+            result = monitor.monitor("artist", a, bitrate, record_type, alerts, remove=remove, dl_obj=dl, downloadPath=downloadPath)
             if type(result) == int:
                 new_artists.append(result)
 
@@ -164,13 +166,13 @@ def monitor_command(artist, im, playlist, no_refresh, bitrate, record_type, aler
 
     if artist_id:
         for aid in artist_id:
-            result = monitor.monitor("artist_id", aid, bitrate, record_type, alerts, remove=remove, dl_obj=dl)
+            result = monitor.monitor("artist_id", aid, bitrate, record_type, alerts, remove=remove, dl_obj=dl, downloadPath=downloadPath)
             if type(result) == int:
                 new_artists.append(result)
 
     if playlists:
         for p in playlists:
-            result = monitor.monitor("playlist", p, bitrate, record_type, alerts, remove=remove, dl_obj=dl)
+            result = monitor.monitor("playlist", p, bitrate, record_type, alerts, remove=remove, dl_obj=dl, downloadPath=downloadPath)
             if type(result) == int:  # TODO is this needed? What return values are possible? if result > 0?
                 new_playlists.append(result)
 

--- a/deemon/cli.py
+++ b/deemon/cli.py
@@ -54,9 +54,10 @@ def test():
 @click.option('-u', '--url', metavar='URL', multiple=True, help='Download by URL of artist/album/track/playlist')
 @click.option('-f', '--file', metavar='FILE', help='Download batch of artists and/or artist IDs from file')
 @click.option('-b', '--bitrate', default=config["bitrate"], help='Set custom bitrate for this operation')
+@click.option('--download-path', type=click.Path(), default=config["download_path"], metavar="PATH", help='Path where the artist/album/track/playlist will be saved')
 @click.option('-t', '--record-type', type=click.Choice(['all', 'album', 'ep', 'single'], case_sensitive=False),
               default=config["record_type"], help='Specify record types to download')
-def download_command(artist, artist_id, album_id, url, file, bitrate, record_type):
+def download_command(artist, artist_id, album_id, url, file, bitrate, record_type, download_path):
     """
     Download specific artist, album ID or by URL
 
@@ -67,13 +68,17 @@ def download_command(artist, artist_id, album_id, url, file, bitrate, record_typ
     """
     bitrate = utils.validate_bitrate(bitrate)
 
+    if download_path:
+        if not (Path(download_path).exists):
+            download_path = config["download_path"]
+
     artists = artists_to_csv(artist) if artist else None
     artist_ids = [x for x in artist_id] if artist_id else None
     album_ids = [x for x in album_id] if album_id else None
     urls = [x for x in url] if url else None
 
     dl = download.Download()
-    dl.download(artists, artist_ids, album_ids, urls, bitrate, record_type, file)
+    dl.download(artists, artist_ids, album_ids, urls, bitrate, record_type, file, downloadPath=download_path)
 
 
 @run.command(name='monitor', context_settings={"ignore_unknown_options": True})


### PR DESCRIPTION
Description :
Allowing to save different artist/playlist/import to specific location.

Information about functionality:
The added functionality allows to control the location where the artist, the playlist or the import of a list of artists will be saved.

When adding an artist to the monitoring, for example, to download it immediately, we will use the "-D or --download" parameter.

I have slightly modified the behavior of this one so that it takes a value in addition. This value will be the destination path of the downloads (for this artist, playlist or import).

This means now that each imported item can have its independence on its location.

In case the path in parameters is incorrect, no error is generated.
But the default path configured in the configuration will be used.

This behavior could be handled via a new config parameter ? (e.g config parameter "if_custom_path_not_exist_use_default": "true|false")
If this parameter is set to false then an exception is generated, because the user doesn't really want to be warned if the path would be invalid. And in the case of true it would behave as currently on the default path in case of problem.
