### PR TITLE
Fix for IndexError and date parsing in deemon and deezer utils

### DIFF
--- a/deemon/utils/dates.py
+++ b/deemon/utils/dates.py
@@ -34,11 +34,15 @@ def format_date_string(d: str):
 def ui_date(d: datetime):
     return datetime.strftime(d, '%b %d, %Y')
 
-def str_to_datetime_obj(d: str) -> datetime:
-    if d == "0000-00-00":
-        d = "1980-01-01"
-    return datetime.strptime(d, "%Y-%m-%d")
-
+ddef str_to_datetime_obj(d: str) -> datetime | None:
+    try:
+        if not d or d.strip() == "" or d.startswith("0000"):
+            logger.warning(f"[dates] Fecha inválida detectada ('{d}'), usando 1980-01-01 como valor predeterminado.")
+            return datetime.strptime("1980-01-01", "%Y-%m-%d")
+        return datetime.strptime(d, "%Y-%m-%d")
+    except Exception as e:
+        logger.error(f"[dates] Error al convertir fecha '{d}': {e}")
+        return None
 
 def get_friendly_date(d: int):
     input_date = datetime.fromtimestamp(d).date()

--- a/deemon/utils/dates.py
+++ b/deemon/utils/dates.py
@@ -37,8 +37,8 @@ def ui_date(d: datetime):
 ddef str_to_datetime_obj(d: str) -> datetime | None:
     try:
         if not d or d.strip() == "" or d.startswith("0000"):
-            logger.warning(f"[dates] Fecha inválida detectada ('{d}'), usando 1980-01-01 como valor predeterminado.")
-            return datetime.strptime("1980-01-01", "%Y-%m-%d")
+            logger.warning(f"[dates] Invalid date detected ('{d}'), using 1900-01-01 as default value.")
+            return datetime.strptime("1900-01-01", "%Y-%m-%d")
         return datetime.strptime(d, "%Y-%m-%d")
     except Exception as e:
         logger.error(f"[dates] Error al convertir fecha '{d}': {e}")


### PR DESCRIPTION
🔧 Summary of Changes

This pull request includes two key improvements to enhance stability when handling edge cases in both date parsing and Deezer track metadata.

---

🗓️ 1. Improved Date Parsing in str_to_datetime_obj()

Before:

def str_to_datetime_obj(d: str) -> datetime:
    if d == "0000-00-00":
        d = "1980-01-01"
    return datetime.strptime(d, "%Y-%m-%d")

After:

def str_to_datetime_obj(d: str) -> datetime | None:
    try:
        if not d or d.strip() == "" or d.startswith("0000"):
            logger.warning(f"[dates] Invalid date detected ('{d}'), defaulting to 1980-01-01.")
            return datetime.strptime("1980-01-01", "%Y-%m-%d")
        return datetime.strptime(d, "%Y-%m-%d")
    except Exception as e:
        logger.error(f"[dates] Error parsing date '{d}': {e}")
        return None

Benefits:
- Handles empty, null, and invalid date strings safely
- Logs warnings and errors with context
- Returns None instead of crashing

---
Note: Although the fix was applied in the deezer/utils.py dependency folder, it is required to prevent crashes caused by invalid API data. If this module is bundled in this repo, the patch ensures stability."

🎵 2. Safe Access to track['MEDIA'] in Deezer Track Mapping

Before:

result['preview'] = track['MEDIA'][0]['HREF']

After:

if 'MEDIA' in track and isinstance(track['MEDIA'], list) and len(track['MEDIA']) > 0:
    result['preview'] = track['MEDIA'][0].get('HREF')
else:
    result['preview'] = None

Benefits:
- Prevents IndexError on empty or missing MEDIA lists
- Uses .get() for safe dictionary access
- Keeps the download process running even with incomplete track data

---

📌 These changes improve fault tolerance and make the tool more reliable when interacting with Deezer.
